### PR TITLE
triple tick goes on newline

### DIFF
--- a/doc/cheatsheet.md
+++ b/doc/cheatsheet.md
@@ -444,8 +444,8 @@ The primary use of binary operations is to operate on data that is most effectiv
 ni //license FWpF_ p'r pl 3' \
      p'json_encode {type    => 'trigram',
                     context => {w1 => a, w2 => b},
-                    word    => c}' \>jsons```
-
+                    word    => c}' \>jsons
+```
 
 ###Array Functions
   * `clip`


### PR DESCRIPTION
Amazing tool. Thank you for documenting the functionality so well! 

This moves the closing triple tick to a newline so that github does not render the rest of the document as part of the code snippet.