### PR TITLE
lisp: failover to text when parsing and disable interactive debugger

### DIFF
--- a/core/lisp/prefix.lisp
+++ b/core/lisp/prefix.lisp
@@ -4,6 +4,14 @@
 (declaim (optimize (speed 3) (safety 0)))
 (setf *read-default-float-format* 'double-float)
 
+;;; abort rather than interactively debug any errors
+(defun abort-debug (condition h)
+  (declare (ignore h))
+  (format t "Lisp error: ~A~%" condition)
+  (abort))
+
+(setf *debugger-hook* #'abort-debug)
+
 ;;; utility functions from wu-sugar
 
 (defun str (&rest values)
@@ -58,10 +66,10 @@
 (defun read-col (text)
   (when text
     (let* ((*read-eval* nil)
-           (r (read-from-string text)))
-      (etypecase r
-        (symbol text)
-        (number r)))))
+           (parsed (ignore-errors (read-from-string text))))
+      (if (numberp parsed)
+          parsed
+          text))))
 
 (defun %r (&rest values)
   (apply #'join #\Tab values))


### PR DESCRIPTION
@spencertipping this solves a couple problems:
1) Any time there is a lisp error, we should just give up. Previously, the interactive lisp debugger would open, which was annoying to get out of (I think key input might have been taken over by ni hence you couldn't quit it in any sane way)
2) Sometimes `read-from-string` errors out on things that superficially look like numbers but actually aren't (e.g. `2015-01-03T04:00:00.902953Z`). In those cases we should just treat those values as text.